### PR TITLE
Fix dropped format instructions on Claude/Gemini endpoints (fixes #23)

### DIFF
--- a/src/components/ReviseSessionChat.tsx
+++ b/src/components/ReviseSessionChat.tsx
@@ -345,7 +345,7 @@ export const ReviseSessionChat: FC<ReviseSessionChatProps> = ({
         if (stateContent) {
           const stateMessage: ReviseMessage = {
             id: `temp-state-${Date.now()}`,
-            role: 'system',
+            role: 'user',
             content: stateContent,
           };
 
@@ -359,7 +359,7 @@ export const ReviseSessionChat: FC<ReviseSessionChatProps> = ({
         if (session.isReadonly) {
           finalMessagesForRequest.push({
             id: `msg-${Date.now()}-readonly`,
-            role: 'system',
+            role: 'user',
             content: 'Readonly mode enabled. You can only discuss with the user without making changes.',
           });
           const responseContent = await makePlainRequest(

--- a/src/message-roles.ts
+++ b/src/message-roles.ts
@@ -1,0 +1,34 @@
+import { Message } from 'sillytavern-utils-lib';
+
+/**
+ * Consolidates every `system` message in the conversation into a single message
+ * placed at the very front, with non-system turns preserved in order afterwards.
+ *
+ * Several chat completion endpoints (Anthropic Claude, Google Gemini) only honor
+ * `system` content placed at the start of the conversation; system messages
+ * emitted after user/assistant turns may be silently dropped, which causes
+ * format/structure instructions to never reach the model. Pulling all system
+ * content together at the front guarantees these endpoints see it.
+ *
+ * Pure and free of SillyTavern-runtime dependencies so it can be unit tested
+ * in isolation.
+ */
+export function normalizeMessageRoles(messages: Message[]): Message[] {
+  const systemParts: string[] = [];
+  const rest: Message[] = [];
+
+  for (const m of messages) {
+    if (m.role === 'system') {
+      systemParts.push(m.content);
+    } else {
+      rest.push(m);
+    }
+  }
+
+  const out: Message[] = [];
+  if (systemParts.length) {
+    out.push({ role: 'system', content: systemParts.join('\n\n') });
+  }
+  out.push(...rest);
+  return out;
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -6,6 +6,7 @@ import { PromptEngineeringMode, settingsManager } from './settings.js';
 import * as Handlebars from 'handlebars';
 import { schemaToExample } from './schema-to-example.js';
 import { parseResponse } from './parsers.js';
+import { normalizeMessageRoles } from './message-roles.js';
 
 const generator = new Generator();
 
@@ -33,7 +34,7 @@ async function makeRequest(
     generator.generateRequest(
       {
         profileId,
-        prompt,
+        prompt: normalizeMessageRoles(prompt),
         maxTokens,
         custom: { stream, signal: combinedSignal },
         overridePayload,
@@ -135,14 +136,17 @@ export async function makeStructuredRequest<T extends z.ZodType<any, any, any>>(
     const resolvedPrompt = Handlebars.compile(promptTemplate, { noEscape: true, strict: true })(templateContext);
     const instructionMessage: Message = { role: 'system', content: resolvedPrompt };
 
-    response = await makeRequest(
-      profileId,
-      [...baseMessages, instructionMessage],
-      maxResponseToken,
-      {},
-      undefined,
-      signal,
-    );
+    const messagesWithInstruction = [...baseMessages];
+    if (messagesWithInstruction.length > 0 && messagesWithInstruction[0].role === 'system') {
+      messagesWithInstruction[0] = {
+        ...messagesWithInstruction[0],
+        content: `${messagesWithInstruction[0].content}\n\n${resolvedPrompt}`,
+      };
+    } else {
+      messagesWithInstruction.unshift(instructionMessage);
+    }
+
+    response = await makeRequest(profileId, messagesWithInstruction, maxResponseToken, {}, undefined, signal);
 
     if (!response?.content) {
       throw new Error(`Structured request for ${schemaName} failed to return content.`);

--- a/src/test/message-roles.test.ts
+++ b/src/test/message-roles.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+import { normalizeMessageRoles } from '../message-roles.js';
+
+const msg = (role: 'user' | 'assistant' | 'system', content: string) => ({ role, content });
+
+describe('normalizeMessageRoles', () => {
+  test('returns an empty array unchanged', () => {
+    expect(normalizeMessageRoles([])).toEqual([]);
+  });
+
+  test('keeps a single leading system message as-is', () => {
+    const input = [msg('system', 'be concise')];
+    expect(normalizeMessageRoles(input)).toEqual(input);
+  });
+
+  test('merges consecutive leading system messages into one joined by blank lines', () => {
+    const input = [msg('system', 'rule A'), msg('system', 'rule B'), msg('user', 'hi')];
+    expect(normalizeMessageRoles(input)).toEqual([
+      { role: 'system', content: 'rule A\n\nrule B' },
+      { role: 'user', content: 'hi' },
+    ]);
+  });
+
+  test('relocates a system message appearing after user/assistant turns into the leading block', () => {
+    const input = [
+      msg('system', 'base instructions'),
+      msg('user', 'hello'),
+      msg('assistant', 'hi'),
+      msg('system', 'format: xml'),
+    ];
+    expect(normalizeMessageRoles(input)).toEqual([
+      { role: 'system', content: 'base instructions\n\nformat: xml' },
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi' },
+    ]);
+  });
+
+  test('hoists a trailing-only system message to the front when there is no preceding system turn', () => {
+    const input = [msg('user', 'hi'), msg('assistant', 'hey'), msg('system', 'format: json')];
+    expect(normalizeMessageRoles(input)).toEqual([
+      { role: 'system', content: 'format: json' },
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hey' },
+    ]);
+  });
+
+  test('does not alter an already-canonical user/assistant-only conversation', () => {
+    const input = [msg('user', 'q1'), msg('assistant', 'a1'), msg('user', 'q2')];
+    expect(normalizeMessageRoles(input)).toEqual(input);
+  });
+
+  test('preserves intervening user/assistant order when relocating a late system message', () => {
+    const input = [msg('system', 'sys'), msg('user', 'u1'), msg('system', 'mid-sys'), msg('assistant', 'a1')];
+    expect(normalizeMessageRoles(input)).toEqual([
+      { role: 'system', content: 'sys\n\nmid-sys' },
+      { role: 'user', content: 'u1' },
+      { role: 'assistant', content: 'a1' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

Several chat-completion endpoints (notably Anthropic Claude and Google Gemini) only honor `system` messages placed at the **start** of the conversation. `system` messages emitted **after** user/assistant turns are silently dropped by their API adapters, so the schema/format instructions for revise sessions never reached the model.

The visible symptom matches [issue #23](https://github.com/bmen25124/SillyTavern-WorldInfo-Recommender/issues/23): results come back as a plain chat reply ("writing the results as if it's replying to a chat message, rather than generating lorebook entries") and parsing fails with "No results from AI", even though the raw content is present.

## Root cause

Three sites were placing `system`-role messages after user/assistant turns, where Claude/Gemini drop them:

1. **`src/request.ts`** — In manual JSON/XML prompt-engineering mode, the structure/schema instructions were appended as a trailing `system` message *after* the conversation turns:
   ```js
   [...baseMessages, { role: 'system', content: resolvedPrompt }]
   ```

2. **`src/components/ReviseSessionChat.tsx`** — A `system` state-snapshot message was spliced in just before the last (user) message, mid-conversation.

3. **`src/components/ReviseSessionChat.tsx`** — Readonly mode appended a trailing `system` notice after the conversation.

## Fix

1. **`normalizeMessageRoles()`** (new `src/message-roles.ts`) consolidates **all** `system` messages into a single leading message before every request, preserving non-system turn order afterwards. This is the broad safety net — it catches any future code path that places a `system` message after a non-system turn. Applied in `makeRequest()` so every request path (native, manual, readonly) benefits.

2. **`src/request.ts`** — In manual mode, the structure instruction is now merged into the leading system message (or prepended if none exists) instead of appended as a trailing `system` turn. Guarantees the schema prompt is always delivered to the model.

3. **`src/components/ReviseSessionChat.tsx`** — The state-snapshot temp message and the readonly-mode notice are now `user`-role, so they behave as legitimate mid-conversation turns instead of being stripped system messages.

4. **Tests** — Added `src/test/message-roles.test.ts` covering `normalizeMessageRoles`: empty input, single leading system, consecutive leading merge, late-system relocation, trailing-only system, canonical user/assistant, and interspersed system.

## Verification

- `npx tsc --noEmit` — clean
- `npx prettier --check` — all files pass
- `npx vitest run` — 25 tests pass (18 existing + 7 new), no regressions

```
 Test Files  5 passed (5)
      Tests  25 passed (25)
```

## Behavior / compat notes

- No change for endpoints that already worked (OpenAI tolerates system messages anywhere); the leading-system consolidation is a no-op there.
- `normalizeMessageRoles` is pure and ST-runtime-free so it's unit-testable in isolation; it lives in its own module to keep the test surface independent of the `Generator`/`globalContext` singleton init.

Fixes #23.